### PR TITLE
Basic audit log

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 Out of the box, it provides:
 
 * Fully functional Akka gRPC service
+* Access log (HTTP based)
 * Basic GitHub Actions workflow
 * Setup for structured logging
 * Basic healthcheck
@@ -48,20 +49,17 @@ However, these are the ones that you will need to fill correctly:
 
 ## Running
 
-The generated service is runnable out of the box and it is ready to be
-deployed wout any required further intervention. To start
-locally:
+The generated service is runnable out of the box. To start locally:
 
 ```
 sbt run
 ```
 
 that listens on port 9000 and answering on a simple healthcheck.
-```
-grpcurl -v --plaintext  localhost:9000 grpc.health.v1.Health/Check
-```
 
-More options are in the generated service README.
+```
+grpcurl --insecure localhost:9000 grpc.health.v1.Health/Check
+```
 
 ## CI/CD setup
 
@@ -82,6 +80,8 @@ We have three different pipelines with their jobs:
 
 ## References
 
+* [Akka gRPC](https://doc.akka.io/docs/akka-grpc/current/index.html)
+* [Akka HTTP](https://doc.akka.io/docs/akka-http/current/index.html)
 * [g8](http://www.foundweekends.org/giter8/)
 * [GitHub actions](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions)
 * [SBT Coverage](https://github.com/scoverage/sbt-scoverage)

--- a/src/main/g8/src/main/scala/$package$/Access.scala
+++ b/src/main/g8/src/main/scala/$package$/Access.scala
@@ -1,0 +1,108 @@
+package $package$
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.RouteResult.Complete
+import akka.http.scaladsl.server.RouteResult.Rejected
+import akka.http.scaladsl.server._
+import net.logstash.logback.argument.StructuredArguments._
+import org.slf4j.Logger
+
+import scala.concurrent.duration._
+
+// \$COVERAGE-OFF\$: not worth it
+
+// This is a stripped down version of the access logger found in the
+// Akka HTTP temaplte: intercepting req/resp at the HTTP level is
+// problematic cause (i) is an abstraction leakage (IMHO), (ii) does
+// not offer all the needed info and (iii) most of the machinery is
+// hidden (e.g. all calls are a POST). For the moment is the best I
+// could do.
+//
+// Note that you will always see a 200 OK even if the response was a
+// Bad Request given that everything gets tunnelled through an always
+// successful HTTP response.
+object Access {
+  private object domain {
+    case class ReqLogEntry(
+      path: String,
+      remote_ip: Option[String] = None,
+      remote_country: Option[String] = None,
+    )
+
+    case class RespLogEntry(
+      status: String,
+      code: Int,
+    )
+  }
+
+  import domain._
+
+  private def headerValueOrNone(req: HttpRequest, name: String) =
+    req.headers.find(_.lowercaseName == name.toLowerCase()).map(_.value)
+
+  // Best effort to figure out the remote caller's IP. We start by looking
+  // at the CloudFlare header to then proceed with the more or less
+  // standard ones.
+  // TODO: Not sure if these are still valid in a gRPC world.
+  private def extractRemoteIP(req: HttpRequest): Option[String] =
+    List(
+      headerValueOrNone(req, "cf-connecting-ip"),
+      headerValueOrNone(req, "X-Forwarded-For"),
+      headerValueOrNone(req, "RemoteAddress"),
+      headerValueOrNone(req, "X-Real-IP"),
+    ).flatten.headOption
+
+  // If we are behind CloudFlare we will be also getting the
+  // originating country.
+  private def extractCountry(req: HttpRequest): Option[String] = headerValueOrNone(req, "Cf-Ipcountry")
+
+  private def asLog(req: HttpRequest): ReqLogEntry =
+    ReqLogEntry(
+      path = req.uri.path.toString,
+      remote_ip = extractRemoteIP(req),
+      remote_country = extractCountry(req),
+    )
+
+  private def asLog(resp: HttpResponse): RespLogEntry = RespLogEntry(status = resp.status.value, code = resp.status.intValue)
+
+  private def akkaResponseTimeLoggingFunction(requestTimestamp: Long, req: HttpRequest, res: RouteResult) = res match {
+    case Complete(resp) =>
+      val responseTimestamp: Long = System.nanoTime()
+      val elapsedTime: Long =
+        (FiniteDuration(responseTimestamp, NANOSECONDS) - FiniteDuration(requestTimestamp, NANOSECONDS)).toMillis // convert to ms
+      (
+        s"""\${req.uri.path} \${resp.status} \$elapsedTime""",
+        Array(
+          value("elapsed_time", elapsedTime),
+          value("request", asLog(req)),
+          value("response", asLog(resp)),
+        ),
+      )
+    case Rejected(reason) =>
+      (
+        s"""Rejected Reason: \${reason.mkString(",")}""",
+        Array(
+          value("request", asLog(req)),
+        ),
+      )
+  }
+
+  def logTimedRequestResponse(logger: Logger) = extractRequestContext.flatMap { ctx =>
+    val requestTimestamp = System.nanoTime()
+    mapRouteResult { resp =>
+      import akka.http.scaladsl.model.Uri.Path
+      // Ignore the reflection calls to avoid too much noise. These
+      // are just gRPC clients trying to figure out if the call is
+      // supported by the server using API introspection.
+      if (!ctx.request.uri.path.startsWith(Path("/grpc.reflection.v1alpha.ServerReflection"))) {
+        val (msg, args) = akkaResponseTimeLoggingFunction(requestTimestamp, ctx.request, resp)
+        logger.info(msg, args.asInstanceOf[Array[Object]]: _*)
+      }
+
+      resp
+    }
+  }
+}
+// \$COVERAGE-ON\$


### PR DESCRIPTION
This is a stripped down version of the access logger found in the
Akka HTTP template: intercepting req/resp at the HTTP level is
problematic cause (i) is an abstraction leakage (IMHO), (ii) does
not offer all the needed info and (iii) most of the machinery is
hidden (e.g. all calls are a POST). For the moment is the best I
could do.

Note that you will always see a 200 OK even if the response was a
(e.g.) 'Bad Request' given that everything gets tunnelled through an
always successful HTTP response.
